### PR TITLE
Change salsanext.yml to salsanext_cuda10.yml in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The up-to-date scores can be found in the Semantic-Kitti [page](http://semantic-
 ## How to use the code
 
 First create the anaconda env with:
-```conda env create -f salsanext.yml``` then activate the environment with ```conda activate salsanext```.
+```conda env create -f salsanext_cuda10.yml --name salsanext``` then activate the environment with ```conda activate salsanext```.
 
 To train/eval you can use the following scripts:
 


### PR DESCRIPTION
There was a confusing typo: the README suggested to create a conda environment from `salsanext.yml` which is actually a file containing training parameters, not an environment file.